### PR TITLE
Fix sGroupUserAdd throw when adding not a user

### DIFF
--- a/CK.DB.Actor/Res/sGroupUserAdd.sql
+++ b/CK.DB.Actor/Res/sGroupUserAdd.sql
@@ -2,7 +2,7 @@
 --
 -- Add a User to a Group. Does nothing if the User is already in the Group.
 --
-alter procedure CK.sGroupUserAdd 
+alter procedure CK.sGroupUserAdd
 (
 	@ActorId int,
 	@GroupId int,
@@ -12,6 +12,9 @@ as begin
     if @ActorId <= 0 throw 50000, 'Security.AnonymousNotAllowed', 1;
     if @GroupId <= 0 throw 50000, 'Group.InvalidId', 1;
 
+    if not exists (select 1 from CK.tUser where UserId = @UserId)
+        throw 50000, 'User.NotAUser', 1;
+
 	-- System is, somehow, already in all groups.
     if @UserId = 1 return 0;
 
@@ -20,9 +23,9 @@ as begin
 	if @GroupId <> @UserId and not exists (select * from CK.tActorProfile where GroupId = @GroupId and ActorId = @UserId)
 	begin
 		-- If this is the System Group, only members of it can add new Users.
-		if @GroupId = 1 
+		if @GroupId = 1
 		begin
-			if not exists( select 1 from CK.tActorProfile p where p.GroupId = 1 and p.ActorId = @ActorId ) 
+			if not exists( select 1 from CK.tActorProfile p where p.GroupId = 1 and p.ActorId = @ActorId )
 			begin
 				;throw 50000, 'Security.ActorMustBeSytem', 1;
 			end

--- a/CK.DB.Actor/Res/sGroupUserAdd.sql
+++ b/CK.DB.Actor/Res/sGroupUserAdd.sql
@@ -14,7 +14,7 @@ as begin
 
     if not exists(select 1 from CK.tUser where UserId = @UserId)
     begin
-        throw 50000, 'User.NotAUser', 1;
+        ;throw 50000, 'User.NotAUser', 1;
     end
 
 	-- System is, somehow, already in all groups.

--- a/CK.DB.Actor/Res/sGroupUserAdd.sql
+++ b/CK.DB.Actor/Res/sGroupUserAdd.sql
@@ -12,8 +12,10 @@ as begin
     if @ActorId <= 0 throw 50000, 'Security.AnonymousNotAllowed', 1;
     if @GroupId <= 0 throw 50000, 'Group.InvalidId', 1;
 
-    if not exists (select 1 from CK.tUser where UserId = @UserId)
+    if not exists(select 1 from CK.tUser where UserId = @UserId)
+    begin
         throw 50000, 'User.NotAUser', 1;
+    end
 
 	-- System is, somehow, already in all groups.
     if @UserId = 1 return 0;

--- a/Tests/CK.DB.Actor.Tests/GroupTests.cs
+++ b/Tests/CK.DB.Actor.Tests/GroupTests.cs
@@ -198,6 +198,8 @@ namespace CK.DB.Actor.Tests
             {
                 var groupId = groupTable.CreateGroup( context, 1 );
 
+                // Directly call the sActorCreate procedure: it is not exposed on the C# side
+                // since there is no point to call it... except from tests.
                 var cmd = new SqlCommand( "CK.sActorCreate" );
                 cmd.CommandType = CommandType.StoredProcedure;
                 cmd.Parameters.Add( "@ActorId", SqlDbType.Int ).Value = 1;

--- a/Tests/CK.DB.Actor.Tests/GroupTests.cs
+++ b/Tests/CK.DB.Actor.Tests/GroupTests.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Data;
+using System.Diagnostics;
 using NUnit.Framework;
 using CK.SqlServer;
 using CK.Core;
 using FluentAssertions;
+using Microsoft.Data.SqlClient;
 using static CK.Testing.DBSetupTestHelper;
 
 namespace CK.DB.Actor.Tests
@@ -180,6 +183,33 @@ namespace CK.DB.Actor.Tests
                 u.DestroyUser( ctx, 1, userId );
                 u.DestroyUser( ctx, 1, userId2 );
                 u.DestroyUser( ctx, 1, anotherUserId );
+            }
+        }
+
+        [Test]
+        public void sGroupUserAdd_should_throw_when_adding_an_actor_that_is_not_a_user()
+        {
+            var groupTable = TestHelper.StObjMap.StObjs.Obtain<GroupTable>();
+            var actorTable = TestHelper.StObjMap.StObjs.Obtain<ActorTable>();
+            Debug.Assert( groupTable != null, nameof( groupTable ) + " != null" );
+            Debug.Assert( actorTable != null, nameof( actorTable ) + " != null" );
+
+            using( var context = new SqlStandardCallContext() )
+            {
+                var groupId = groupTable.CreateGroup( context, 1 );
+
+                var cmd = new SqlCommand( "CK.sActorCreate" );
+                cmd.CommandType = CommandType.StoredProcedure;
+                cmd.Parameters.Add( "@ActorId", SqlDbType.Int ).Value = 1;
+                cmd.Parameters.Add( "@ActorIdResult", SqlDbType.Int ).Direction = ParameterDirection.Output;
+                actorTable.Database.ExecuteNonQuery( cmd );
+                var actorIdResult = Convert.ToInt32( cmd.Parameters["@ActorIdResult"].Value );
+
+                groupTable.Invoking( sut => sut.AddUser( context, 1, groupId, actorIdResult ) )
+                          .Should()
+                          .Throw<SqlDetailedException>()
+                          .WithInnerException<SqlException>()
+                          .WithMessage( "User.NotAUser" );
             }
         }
 

--- a/Tests/TestHelper.config
+++ b/Tests/TestHelper.config
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
+
 <configuration>
-    <appSettings>
-        <add key="WorkingDirectory" value="{TestProjectName}/CKSetup-WorkingDir" />
-    </appSettings>
+  <appSettings>
+    <add key="WorkingDirectory" value="{TestProjectName}/CKSetup-WorkingDir" />
+    <add key="Monitor/LogToText" value="true" />
+  </appSettings>
 </configuration>


### PR DESCRIPTION
A simple actor is not considered as a user for example.
This fix gives the opportunity to extend the group usage to add specific actor type.

Add text logs for Tests.